### PR TITLE
feat: Replace mona handle with professortocat handle

### DIFF
--- a/.github/steps/2-running-our-extension.md
+++ b/.github/steps/2-running-our-extension.md
@@ -43,10 +43,10 @@ Before we start customizing, let's try running the template extension that was p
    1. Right click on the URL and select **Open in Browser**.
    1. You should see a web page describing your extension!
 
-1. Leave the debugger running to keep the service alive, and add an issue comment using the example below. Make sure you tag @mona to notify her and to update the link!
+1. Leave the debugger running to keep the service alive, and add an issue comment using the example below. Make sure you tag Professor Octocat to notify her and to update the link!
 
    ```markdown
-   Hey @mona, please check if my codespace is running correctly.
+   Hey @professortocat, please check if my codespace is running correctly.
 
    https://my-codespace-link-3000.app.github.dev
    ```

--- a/.github/steps/3-connecting-to-github.md
+++ b/.github/steps/3-connecting-to-github.md
@@ -66,7 +66,7 @@ Let's check if our extension service is available to use on github.com and in ou
 1. After you are done configuring your **GitHub App** and testing the connection, leave the following comment on the issue to let Mona know you are ready for the next step.
 
    ```markdown
-   Hey @mona, I'm all done configuring my GitHub App. Here's the link. What's next?
+   Hey @professortocat, I'm all done configuring my GitHub App. Here's the link. What's next?
 
    https://github.com/apps/my-ghc-extension-{{login}}
    ```

--- a/.github/workflows/2-running-our-extension.yml
+++ b/.github/workflows/2-running-our-extension.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   # Keywords required in the issue comment to let this workflow run
-  REQUIRED_ISSUE_COMMENT_KEYWORDS: "@mona,https,app.github.dev"
+  REQUIRED_ISSUE_COMMENT_KEYWORDS: "@professortocat,https,app.github.dev"
   STEP_3_FILE: ".github/steps/3-connecting-to-github.md"
 
 jobs:

--- a/.github/workflows/3-connecting-to-github.yml
+++ b/.github/workflows/3-connecting-to-github.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   # Keywords required in the issue comment to allow this workflow to run
-  REQUIRED_ISSUE_COMMENT_KEYWORDS: "@mona,https://github.com/apps"
+  REQUIRED_ISSUE_COMMENT_KEYWORDS: "@professortocat,https://github.com/apps"
   STEP_4_FILE: ".github/steps/4-customizing-our-extension.md"
 
 jobs:


### PR DESCRIPTION
Replaces the `@mona` handle with the `@professortocat` handle to avoid sending to many mention notifications to the team that owns that account.