### PR TITLE
fix: complex issue and comment content causing CLI command failures

### DIFF
--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -126,10 +126,11 @@ jobs:
         run: |
           issue_url=$(gh issue create \
             --title "Exercise: $EXERCISE_NAME" \
-            --body "${{ steps.build-issue-description.outputs.updated-text }}")
+            --body "$ISSUE_BODY")
           echo "ISSUE_URL=$issue_url" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_BODY: ${{ steps.build-issue-description.outputs.updated-text }}
 
   post_next_step_content:
     name: Post next step content
@@ -165,10 +166,10 @@ jobs:
       - name: Create comment - add step content
         run: |
           gh issue comment "$ISSUE_URL" \
-            --body "$ISSUE_BODY"
+            --body "$COMMENT_BODY"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_BODY: ${{ steps.build-comment.outputs.updated-text }}
+          COMMENT_BODY: ${{ steps.build-comment.outputs.updated-text }}
 
       - name: Create comment - watching for progress
         run: |

--- a/.github/workflows/1-preparing.yml
+++ b/.github/workflows/1-preparing.yml
@@ -78,10 +78,11 @@ jobs:
       - name: Update comment - step finished
         run: |
           gh issue comment "$ISSUE_URL" \
-            --body "${{ steps.build-message-step-finish.outputs.updated-text }}" \
+            --body "$ISSUE_BODY" \
             --edit-last
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_BODY: ${{ steps.build-message-step-finish.outputs.updated-text }}
 
   post_next_step_content:
     name: Post next step content

--- a/.github/workflows/2-running-our-extension.yml
+++ b/.github/workflows/2-running-our-extension.yml
@@ -24,11 +24,13 @@ jobs:
         run: |
           required_keywords=(${REQUIRED_ISSUE_COMMENT_KEYWORDS//,/ })
           for keyword in "${required_keywords[@]}"; do
-          if [[ ! "${{ github.event.comment.body }}" =~ $keyword ]]; then
+          if [[ ! "$COMMENT_BODY" =~ $keyword ]]; then
             echo "Unrecognized request. Ending workflow."
             exit 0
           fi
           done
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
 
   find_exercise:
     name: Find exercise by issue title
@@ -118,10 +120,11 @@ jobs:
       - name: Update comment - step finished
         run: |
           gh issue comment "$ISSUE_URL" \
-            --body "${{ steps.build-message-step-finish.outputs.updated-text }}" \
+            --body "$COMMENT_BODY" \
             --edit-last
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_BODY: ${{ steps.build-message-step-finish.outputs.updated-text }}
 
   post_next_step_content:
     name: Post next step content
@@ -158,10 +161,10 @@ jobs:
       - name: Create comment - add step content
         run: |
           gh issue comment "$ISSUE_URL" \
-            --body "$ISSUE_BODY"
+            --body "$COMMENT_BODY"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_BODY: ${{ steps.build-comment.outputs.updated-text }}
+          COMMENT_BODY: ${{ steps.build-comment.outputs.updated-text }}
 
       - name: Create comment - watching for progress
         run: |

--- a/.github/workflows/3-connecting-to-github.yml
+++ b/.github/workflows/3-connecting-to-github.yml
@@ -24,10 +24,12 @@ jobs:
         run: |
           required_keywords=(${REQUIRED_ISSUE_COMMENT_KEYWORDS//,/ })
           for keyword in "${required_keywords[@]}"; do
-          if [[ ! "${{ github.event.comment.body }}" =~ $keyword ]]; then
+          if [[ ! "$COMMENT_BODY" =~ $keyword ]]; then
             exit 1
           fi
           done
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
 
   find_exercise:
     name: Find exercise by issue title
@@ -109,10 +111,11 @@ jobs:
       - name: Update comment - step finished
         run: |
           gh issue comment "$ISSUE_URL" \
-            --body "${{ steps.build-message-step-finish.outputs.updated-text }}" \
+            --body "$COMMENT_BODY" \
             --edit-last
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_BODY: ${{ steps.build-message-step-finish.outputs.updated-text }}
 
   post_step_4_content:
     name: Post step 4 content
@@ -148,10 +151,10 @@ jobs:
       - name: Create comment - add step content
         run: |
           gh issue comment "$ISSUE_URL" \
-            --body "$ISSUE_BODY"
+            --body "$COMMENT_BODY"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_BODY: ${{ steps.build-comment.outputs.updated-text }}
+          COMMENT_BODY: ${{ steps.build-comment.outputs.updated-text }}
 
       - name: Create comment - watching for progress
         run: |

--- a/.github/workflows/4-customizing-our-extension.yml
+++ b/.github/workflows/4-customizing-our-extension.yml
@@ -156,9 +156,10 @@ jobs:
       - name: Update comment - step finished
         run: |
           gh issue comment "$ISSUE_URL" \
-            --body "${{ steps.build-message-step-finish.outputs.updated-text }}"
+            --body "$COMMENT_BODY"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_BODY: ${{ steps.build-message-step-finish.outputs.updated-text }}
 
   post_step_4_content:
     name: Post step 4 content

--- a/.github/workflows/5-merge-our-changes.yml
+++ b/.github/workflows/5-merge-our-changes.yml
@@ -124,7 +124,7 @@ jobs:
         run: |
           # Add "Congratulations" to the start of the README
           orig_readme=$(cat README.md)
-          new_readme="${{ steps.build-message-congratulations.outputs.updated-text }} $orig_readme"
+          new_readme="$MESSAGE $orig_readme"
 
           # Update file and push
           echo "$new_readme" > README.md
@@ -133,6 +133,7 @@ jobs:
           git push
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MESSAGE: ${{ steps.build-message-congratulations.outputs.updated-text }}
 
       - name: Build message - exercise finished
         id: build-finish-message
@@ -146,9 +147,10 @@ jobs:
       - name: Create comment - exercise finished
         run: |
           gh issue comment "$ISSUE_URL" \
-            --body "${{ steps.build-finish-message.outputs.updated-text }}"
+            --body "$COMMENT_BODY"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_BODY: ${{ steps.build-finish-message.outputs.updated-text }}
 
       - name: Close issue
         run: gh issue close "$ISSUE_URL"


### PR DESCRIPTION
This pull request fixes an issue where complex issue descriptions and issue comments are loaded from a file. These complex text bodies include single and double quotes. Because they are directly injected into the CLI command, they are not escaped properly and hence fail the command. This is fixed by passing the content through environment variables.