### PR TITLE
docs: update discussion link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,6 @@ In this exercise, you will:
 
 ---
 
-Get help: [Post in our discussion board](https://github.com/orgs/skills/discussions/categories/introduction-to-github) &bull; [Review the GitHub status page](https://www.githubstatus.com/)
+Get help: [Post in our discussion board](https://github.com/orgs/skills/discussions/categories/your-first-extension-for-github-copilot) &bull; [Review the GitHub status page](https://www.githubstatus.com/)
 
 &copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the link to the discussion board to point to the "your-first-extension-for-github-copilot" category.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63-R63): Updated the discussion board link to the correct category.